### PR TITLE
Fix override parameter being treated as always true

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -35,7 +35,7 @@ steps:
 
             echo "jq is already installed..."
 
-          if [[ <<parameters.override>> ]]; then
+          if [[ <<parameters.override>> == true ]]; then
             echo "removing it."
             $SUDO rm -f $(command -v jq)
           else


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

See https://github.com/CircleCI-Public/jq-orb/issues/16

### Description

Changes the condition in the `if` statement so that it satisfied iff `override` is `true`, rather than being satisfied always.

Fixes #16.