### PR TITLE
Remove use of sudo command where possible [semver:minor]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -13,7 +13,7 @@ parameters:
 
   install-dir:
     type: string
-    default: /usr/local/bin
+    default: ~/bin
     description: >
       Directory in which to install jq
 
@@ -29,6 +29,13 @@ steps:
       name: Install jq
       command: |
         if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+
+        if [ ! -f << parameters.install-dir >> ]; then
+          mkdir -p << parameters.install-dir >>
+        fi
+
+        echo 'export PATH=$PATH:<< parameters.install-dir >>' >> $BASH_ENV
+        source $BASH_ENV
 
         # check if jq needs to be installed
         if command -v jq >> /dev/null 2>&1; then
@@ -103,8 +110,8 @@ steps:
             "$JQ_BINARY_URL"
         fi
 
-        $SUDO mv "$jqBinary" <<parameters.install-dir>>/jq
-        $SUDO chmod +x <<parameters.install-dir>>/jq
+        mv "$jqBinary" <<parameters.install-dir>>/jq
+        chmod +x <<parameters.install-dir>>/jq
 
         # cleanup
         [[ -d "./$JQ_VERSION" ]] && rm -rf "./$JQ_VERSION"

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -28,6 +28,9 @@ steps:
   - run:
       name: Install jq
       command: |
+        # Quietly try to make the install directory.
+        mkdir -p << parameters.install-dir >> | true
+
         # Selectively export the SUDO command, depending if we have permission
         # for a directory and whether we're running alpine.
         if [[ $EUID == 0 ]]; then export SUDO=""; else # Check if we're root
@@ -36,6 +39,7 @@ steps:
           fi
         fi
 
+        # If our first mkdir didn't succeed, we needed to run as sudo.
         if [ ! -f << parameters.install-dir >> ]; then
           $SUDO mkdir -p << parameters.install-dir >>
         fi

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -34,13 +34,13 @@ steps:
         # Selectively export the SUDO command, depending if we have permission
         # for a directory and whether we're running alpine.
         if [[ $EUID == 0 ]]; then export SUDO=""; else # Check if we're root
-          if cat /etc/issue | grep Alpine > /dev/null 2>&1 || ! [[ -r "<< parameters.install-dir >>" ]]; then
+          if cat /etc/issue | grep Alpine > /dev/null 2>&1 || ! [[ -w "<< parameters.install-dir >>" ]]; then
             export SUDO="sudo";
           fi
         fi
 
         # If our first mkdir didn't succeed, we needed to run as sudo.
-        if [ ! -f << parameters.install-dir >> ]; then
+        if [ ! -w << parameters.install-dir >> ]; then
           $SUDO mkdir -p << parameters.install-dir >>
         fi
 

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -28,10 +28,16 @@ steps:
   - run:
       name: Install jq
       command: |
-        if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+        # Selectively export the SUDO command, depending if we have permission
+        # for a directory and whether we're running alpine.
+        if [[ $EUID == 0 ]]; then export SUDO=""; else # Check if we're root
+          if cat /etc/issue | grep Alpine > /dev/null 2>&1 || ! [[ -r "<< parameters.install-dir >>" ]]; then
+            export SUDO="sudo";
+          fi
+        fi
 
         if [ ! -f << parameters.install-dir >> ]; then
-          mkdir -p << parameters.install-dir >>
+          $SUDO mkdir -p << parameters.install-dir >>
         fi
 
         echo 'export PATH=$PATH:<< parameters.install-dir >>' >> $BASH_ENV
@@ -110,8 +116,8 @@ steps:
             "$JQ_BINARY_URL"
         fi
 
-        mv "$jqBinary" <<parameters.install-dir>>/jq
-        chmod +x <<parameters.install-dir>>/jq
+        $SUDO mv "$jqBinary" <<parameters.install-dir>>/jq
+        $SUDO chmod +x <<parameters.install-dir>>/jq
 
         # cleanup
         [[ -d "./$JQ_VERSION" ]] && rm -rf "./$JQ_VERSION"


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

See #7 - `sudo` may not always be available or possible to use.

### Description

We attempt to utilize the `sudo` command as few times as possible, opting to install the binary in the user's own directory and add that to their PATH. `sudo` cannot be avoided all the time, e.g removing the binary to override it or using `apk add`, but otherwise installation can be done under a user's own PATH.

Note this does also open the possibility of caching the binary so we can reduce the number of times we have to reach out to GitHub, much like how the UPX orb install functions (https://github.com/CircleCI-Public/UPX-orb/blob/master/src/commands/install.yml).