### PR TITLE
fix: update jq source location to new official location

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -9,7 +9,7 @@ parameters:
     description: >
       Version of jq to install, defaults to `latest`. If specifying a
       version other than latest, provide a full release tag, as listed at
-      https://api.github.com/repos/stedolan/jq/releases, e.g., `jq-1.6`.
+      https://api.github.com/repos/jqlang/jq/releases, e.g., `jq-1.7`.
 
   install-dir:
     type: string
@@ -70,7 +70,7 @@ steps:
 
         # Set jq version
         if [[ <<parameters.version>> == "latest" ]]; then
-          JQ_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/stedolan/jq/releases/latest" | sed 's:.*/::')
+          JQ_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/jqlang/jq/releases/latest" | sed 's:.*/::')
           echo "Latest version of jq is $JQ_VERSION"
         else
           JQ_VERSION=<<parameters.version>>
@@ -84,10 +84,10 @@ steps:
         # Set binary download URL for specified version
         # handle mac version
         if uname -a | grep Darwin > /dev/null 2>&1; then
-          JQ_BINARY_URL="https://github.com/stedolan/jq/releases/download/${JQ_VERSION}/jq-osx-amd64"
+          JQ_BINARY_URL="https://github.com/jqlang/jq/releases/download/${JQ_VERSION}/jq-osx-amd64"
         else
           # linux version
-          JQ_BINARY_URL="https://github.com/stedolan/jq/releases/download/${JQ_VERSION}/jq-linux64"
+          JQ_BINARY_URL="https://github.com/jqlang/jq/releases/download/${JQ_VERSION}/jq-linux64"
         fi
 
         jqBinary="jq-$PLATFORM"


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

On the 9th of September, 2023, "jq" team moved the source files to a new location `https://github.com/jqlang/jq`.  Please see the notes [here](https://github.com/jqlang/jq/releases/tag/jq-1.7).  This update was motivated because builds that required `jq/install` were breaking returning a 404 when trying to install `jq` from it's old location. 

### Description

- Changed all references of the `jq` source from existing location: `https://github.com/stedolan/jq` to new location: `https://github.com/jqlang/jq`
