### PR TITLE
fix: jq release url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,22 @@
 version: 2.1
 
 orbs:
-  build-tools: circleci/build-tools@2.5.0
   orb-tools: circleci/orb-tools@9.0
   jq: circleci/jq@<<pipeline.parameters.dev-orb-version>>
 
+executors:
+  docker-base:
+    docker:
+      - image: cimg/base:stable
+  macos:
+    macos:
+      xcode: 14.2.0
+  machine:
+    machine:
+      image: ubuntu-2004:202101-01
+  alpine:
+    docker:
+      - image: alpine:latest
 # Pipeline parameters
 parameters:
   # These pipeline parameters are required by the "trigger-integration-tests-workflow"
@@ -27,8 +39,6 @@ jobs:
 
     executor: <<parameters.executor>>
     steps:
-      - build-tools/install-ci-tools
-
       - jq/install:
           version: <<parameters.version>>
 
@@ -71,7 +81,7 @@ workflows:
       # latest
       - install:
           name: install-latest-alpine
-          executor: orb-tools/alpine
+          executor: alpine
           context: orb-publisher
           # Test that files are not left behind
           post-steps:
@@ -79,7 +89,7 @@ workflows:
 
       - install:
           name: install-latest-machine
-          executor: orb-tools/machine
+          executor: machine
           context: orb-publisher
           # Test that files are not left behind
           post-steps:
@@ -87,7 +97,7 @@ workflows:
 
       - install:
           name: install-latest-macos
-          executor: orb-tools/macos
+          executor: macos
           context: orb-publisher
           # Test that files are not left behind
           post-steps:
@@ -95,7 +105,7 @@ workflows:
 
       - install:
           name: install-latest-docker
-          executor: orb-tools/node
+          executor: docker-base
           context: orb-publisher
           # Test that files are not left behind
           post-steps:
@@ -112,7 +122,7 @@ workflows:
       # older jq
       - install:
           name: install-older-alpine
-          executor: orb-tools/alpine
+          executor: alpine
           version: jq-1.5
           context: orb-publisher
           # Test that files are not left behind

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ executors:
   machine:
     machine:
       image: ubuntu-2004:202101-01
-  alpine:
-    docker:
-      - image: alpine:latest
 # Pipeline parameters
 parameters:
   # These pipeline parameters are required by the "trigger-integration-tests-workflow"
@@ -81,7 +78,7 @@ workflows:
       # latest
       - install:
           name: install-latest-alpine
-          executor: alpine
+          executor: orb-tools/alpine
           context: orb-publisher
           # Test that files are not left behind
           post-steps:
@@ -122,7 +119,7 @@ workflows:
       # older jq
       - install:
           name: install-older-alpine
-          executor: alpine
+          executor: orb-tools/alpine
           version: jq-1.5
           context: orb-publisher
           # Test that files are not left behind

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ workflows:
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           ssh-fingerprints: 0c:0f:b7:32:1f:7e:55:1b:f9:e9:ba:93:f9:4f:e1:e3
-          context: orb-publisher
+          context: orb-publishing
           orb-name: circleci/jq
           add-pr-comment: true
           bot-token-variable: GHI_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,12 +57,12 @@ workflows:
       - orb-tools/pack
 
       - orb-tools/publish-dev:
-          context: orb-publishing
+          context: orb-publisher
           orb-name: circleci/jq
           requires: *orb_prep_jobs
 
       - orb-tools/trigger-integration-tests-workflow:
-          context: orb-publishing
+          context: orb-publisher
           requires: [orb-tools/publish-dev]
 
   integration_tests-prod_deploy:
@@ -72,7 +72,7 @@ workflows:
       - install:
           name: install-latest-alpine
           executor: orb-tools/alpine
-          context: orb-publishing
+          context: orb-publisher
           # Test that files are not left behind
           post-steps:
             - checkout
@@ -80,7 +80,7 @@ workflows:
       - install:
           name: install-latest-machine
           executor: orb-tools/machine
-          context: orb-publishing
+          context: orb-publisher
           # Test that files are not left behind
           post-steps:
             - checkout
@@ -88,7 +88,7 @@ workflows:
       - install:
           name: install-latest-macos
           executor: orb-tools/macos
-          context: orb-publishing
+          context: orb-publisher
           # Test that files are not left behind
           post-steps:
             - checkout
@@ -96,7 +96,7 @@ workflows:
       - install:
           name: install-latest-docker
           executor: orb-tools/node
-          context: orb-publishing
+          context: orb-publisher
           # Test that files are not left behind
           post-steps:
             - checkout
@@ -104,7 +104,7 @@ workflows:
       - install:
           name: install-latest-oracle
           executor: orb-tools/oracle
-          context: orb-publishing
+          context: orb-publisher
           # Test that files are not left behind
           post-steps:
             - checkout
@@ -114,14 +114,14 @@ workflows:
           name: install-older-alpine
           executor: orb-tools/alpine
           version: jq-1.5
-          context: orb-publishing
+          context: orb-publisher
           # Test that files are not left behind
           post-steps:
             - checkout
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           ssh-fingerprints: 0c:0f:b7:32:1f:7e:55:1b:f9:e9:ba:93:f9:4f:e1:e3
-          context: orb-publishing
+          context: orb-publisher
           orb-name: circleci/jq
           add-pr-comment: true
           bot-token-variable: GHI_TOKEN

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -9,7 +9,7 @@ parameters:
     description: >
       Version of jq to install, defaults to `latest`. If specifying a
       version other than latest, provide a full release tag, as listed at
-      https://api.github.com/repos/stedolan/jq/releases, e.g., `jq-1.6`.
+      https://api.github.com/repos/jqlang/jq/releases, e.g., `jq-1.6`.
 
   install-dir:
     type: string
@@ -70,7 +70,7 @@ steps:
 
         # Set jq version
         if [[ <<parameters.version>> == "latest" ]]; then
-          JQ_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/stedolan/jq/releases/latest" | sed 's:.*/::')
+          JQ_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/jqlang/jq/releases/latest" | sed 's:.*/::')
           echo "Latest version of jq is $JQ_VERSION"
         else
           JQ_VERSION=<<parameters.version>>
@@ -84,10 +84,10 @@ steps:
         # Set binary download URL for specified version
         # handle mac version
         if uname -a | grep Darwin > /dev/null 2>&1; then
-          JQ_BINARY_URL="https://github.com/stedolan/jq/releases/download/${JQ_VERSION}/jq-osx-amd64"
+          JQ_BINARY_URL="https://github.com/jqlang/jq/releases/download/${JQ_VERSION}/jq-osx-amd64"
         else
           # linux version
-          JQ_BINARY_URL="https://github.com/stedolan/jq/releases/download/${JQ_VERSION}/jq-linux64"
+          JQ_BINARY_URL="https://github.com/jqlang/jq/releases/download/${JQ_VERSION}/jq-linux64"
         fi
 
         jqBinary="jq-$PLATFORM"


### PR DESCRIPTION
`jq` has changed their github repository. This `PR` updates the url so that `jq` can be downloaded and installed correctly. 

